### PR TITLE
Launcher fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,19 +117,27 @@ A component for placing your feedback items in a flyout tray that opens from the
 
 ```html
 <d2l-labs-user-feedback-flyout button-text="launch the feedback component">
-	<!-- slot in the container -->
+	<!-- slotted d2l-labs-user-feedback-container -->
 </d2l-labs-user-feedback-flyout>
 ```
 
 #### Attributes
 - `button-text`: the text that you want to place on the button
 
+### d2l-labs-user-feedback-launcher
+A component for placing your feedback items in a d2l-dialog that opens when the user clicks the button. Will only appear after the container loads the hypermedia entities for submitting to the api, after the user has submitted feedback and closed the dialog, it disappears
+
 ```html
-<d2l-labs-user-feedback-flyout
-	button-text="launch the feedback component">
+<d2l-labs-user-feedback-launcher
+	button-text="launch the feedback component"
+>
 	<!-- slotted d2l-labs-user-feedback-container -->
-</d2l-labs-user-feedback-flyout>
+</d2l-labs-user-feedback-launcher>
 ```
+
+#### Attributes
+- `button-text`: the text that you want to place on the button
+- `dialog-title`: set this to override the default dialog title
 
 ## Developing, Testing and Contributing
 

--- a/index.html
+++ b/index.html
@@ -117,11 +117,13 @@
 						'href': 'https://99d6c88f-3f9e-45e6-b804-988b1f68e463.feedback.api.dev.brightspace.com/applications/portfolio/opt-out',
 						'name': 'opt-out',
 						'method': 'POST',
-						'fields': [{ name: 'opt-out-state', value: [
-							{ name: 'temporary', value: 'temporary' },
-							{ name: 'permanent', value: 'permanent' },
-							{ name: 'opt-in', value: null },
-						]}]
+						'fields': [{
+							name: 'opt-out-state', value: [
+								{ name: 'temporary', value: 'temporary' },
+								{ name: 'permanent', value: 'permanent' },
+								{ name: 'opt-in', value: null },
+							]
+						}]
 					}
 				],
 				'links': [
@@ -155,13 +157,10 @@
 			</d2l-labs-user-feedback-scale>
 		</d2l-demo-snippet>
 
-		<h2>d2l-labs-user-feedback-flyout</h2>
+		<h2>d2l-labs-user-feedback-launcher</h2>
 		<d2l-demo-snippet>
-			See the button fixed to the bottom of the screen
-			<d2l-labs-user-feedback-flyout
-				style='position: fixed; bottom: 0; left: 0; z-index: 19;'
-				button-text='launch the d2l-user-flyout-demo'
-			>
+			<d2l-labs-user-feedback-launcher>
+				Launch the thing
 				<d2l-labs-user-feedback-container
 					prompt='Container Prompt'
 					feedback-version='1'
@@ -169,7 +168,43 @@
 					feedback-type='portfolio-instructor-approval'
 					feedback-href='https://99d6c88f-3f9e-45e6-b804-988b1f68e463.feedback.api.dev.brightspace.com/'
 					token='This,AToken'
+					slot='dialog-content'
 				>
+					<d2l-labs-user-feedback-text-input defaultlabeltext='Type something here'>
+						<d2l-labs-user-feedback-scale prompt='How do you like using our product?'>
+							<d2l-labs-user-feedback-scale-item value='1' selectedtextprompt='Why do you hate it?'>
+								I hate it
+							</d2l-labs-user-feedback-scale-item>
+							<d2l-labs-user-feedback-scale-item value='2' selectedtextprompt="Why don't you like it?">
+								I don't like it
+							</d2l-labs-user-feedback-scale-item>
+							<d2l-labs-user-feedback-scale-item value='3'
+								selectedtextprompt='What could we do to make the experience better?'>
+								It's alright
+							</d2l-labs-user-feedback-scale-item>
+							<d2l-labs-user-feedback-scale-item value='4' selectedtextprompt='Why do you like it?'>
+								It's good
+							</d2l-labs-user-feedback-scale-item>
+							<d2l-labs-user-feedback-scale-item value='5'
+								selectedtextprompt='Is that a good thing? Please elaborate.'>
+								It's better than french toast
+							</d2l-labs-user-feedback-scale-item>
+						</d2l-labs-user-feedback-scale>
+					</d2l-labs-user-feedback-text-input>
+				</d2l-labs-user-feedback-container>
+			</d2l-labs-user-feedback-launcher>
+		</d2l-demo-snippet>
+
+
+	<h2>d2l-labs-user-feedback-flyout</h2>
+		<d2l-demo-snippet>
+			See the button fixed to the bottom of the screen
+			<d2l-labs-user-feedback-flyout style='position: fixed; bottom: 0; left: 0; z-index: 19;'
+				button-text='launch the d2l-user-flyout-demo'>
+				<d2l-labs-user-feedback-container prompt='Container Prompt' feedback-version='1'
+					feedback-application='portfolio' feedback-type='portfolio-instructor-approval'
+					feedback-href='https://99d6c88f-3f9e-45e6-b804-988b1f68e463.feedback.api.dev.brightspace.com/'
+					token='This,AToken'>
 					<d2l-labs-user-feedback-text-input defaultlabeltext='Type something here'>
 						<d2l-labs-user-feedback-scale prompt='How do you like using our product?'>
 							<d2l-labs-user-feedback-scale-item value='1' selectedtextprompt='Why do you hate it?'>

--- a/index.html
+++ b/index.html
@@ -159,8 +159,9 @@
 
 		<h2>d2l-labs-user-feedback-launcher</h2>
 		<d2l-demo-snippet>
-			<d2l-labs-user-feedback-launcher>
-				Launch the thing
+			<d2l-labs-user-feedback-launcher
+				button-text='launch the thing'
+			>
 				<d2l-labs-user-feedback-container
 					prompt='Container Prompt'
 					feedback-version='1'

--- a/user-feedback-flyout.js
+++ b/user-feedback-flyout.js
@@ -21,7 +21,7 @@ class UserFeedbackScaleItem extends LitElement {
 			hideafterclose: { type: Boolean },
 			stopscroll: { type: Boolean },
 			buttontext: { type: String, attribute: 'button-text' },
-			_restricted: { type: Boolean }
+			_restricted: { type: Boolean, attribute: false }
 		};
 	}
 

--- a/user-feedback-launcher.js
+++ b/user-feedback-launcher.js
@@ -9,8 +9,8 @@ class UserFeedbackLauncher extends LocalizeMixin(LitElement) {
 
 	static get properties() {
 		return {
-			prompt: { type: String },
-			dialogtitle: { type: String },
+			dialogTitle: { type: String, attribute: 'dialog-title' },
+			buttonText: { type: String, attribute: 'button-text' },
 			hide: { type: Boolean, value: false },
 			_restricted: { type: Boolean },
 		};
@@ -115,14 +115,14 @@ class UserFeedbackLauncher extends LocalizeMixin(LitElement) {
 				class="feedback-launcher"
 				primary
 			>
-				<slot></slot>
+				${this.buttonText}
 			</d2l-button>`;
 
 		return html`
 			${button}
 			<d2l-dialog
 				width="700"
-				title-text="${this.dialogtitle || this.localize('defaultTitle')}"
+				title-text="${this.dialogTitle || this.localize('defaultTitle')}"
 				@d2l-labs-user-feedback-container-cancel="${this._onCancel}"
 				@d2l-labs-user-feedback-container-reject="${this._onReject}"
 				@d2l-labs-user-feedback-container-submit="${this._onSubmit}"

--- a/user-feedback-launcher.js
+++ b/user-feedback-launcher.js
@@ -12,7 +12,7 @@ class UserFeedbackLauncher extends LocalizeMixin(LitElement) {
 			dialogTitle: { type: String, attribute: 'dialog-title' },
 			buttonText: { type: String, attribute: 'button-text' },
 			hide: { type: Boolean, value: false },
-			_restricted: { type: Boolean },
+			_restricted: { type: Boolean, attribute: false },
 		};
 	}
 


### PR DESCRIPTION
Adds "clear on cancel" and handles the `d2l-labs-user-feedback-show-button` event that the user-feedback-container sends when it's ready