### PR TITLE
referencing hypermedia-constants from GitHub

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "@brightspace-ui/core": "^1",
     "@webcomponents/webcomponentsjs": "^2",
     "d2l-alert": "BrightspaceUI/alert#semver:^4",
-    "d2l-hypermedia-constants": "^6.30.0",
+    "d2l-hypermedia-constants": "Brightspace/d2l-hypermedia-constants#semver:^6",
     "d2l-inputs": "BrightspaceUI/inputs#semver:^2",
     "d2l-loading-spinner": "BrightspaceUI/loading-spinner#semver:^7",
     "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",


### PR DESCRIPTION
Unfortunately this needs to be a GitHub reference for now. There's a bunch of other stuff in BSI (8 other projects) using a GitHub reference, so now that this is in BSI it's causing multiple copies to exist.

If I have time, I can go through all 9 projects and switch them to a NPM reference all at once.